### PR TITLE
feat: Auto detect either `uv` or `juv` executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+For a full list of changes, please refer to the
+[GitHub Releases](https://github.com/manzt/juv-vscode/releases).

--- a/README.md
+++ b/README.md
@@ -1,13 +1,20 @@
-# juv-vscode
+# juv
 
-An experimental VS Code extension for [juv](https://github.com/manzt/juv).
+Official VS Code extension for [juv](https://github.com/manzt/juv): reproducible
+Jupyter notebooks, powered by uv.
 
 ## Requirements
 
-Requires the
-[VS Code Python](https://code.visualstudio.com/docs/languages/python) extension
-and for [`juv`](https://github.com/manzt/juv) CLI to be installed globally.
+- VS Code
+  [Jupyter extension](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter)
+- Either:
+  - [`uv`](https://github.com/astral-sh/uv) (**recommended**)
+  - [`juv`](https://github.com/manzt/juv)
 
-```sh
-uv tool install juv@latest
-```
+By default, the extension prioritizes invoking `juv` CLI through the
+[`uv tool` interface](https://docs.astral.sh/uv/concepts/tools/#the-uv-tool-interface)
+(i.e., `uvx juv`). If `uv` is not available, it falls back to calling `juv`
+directly (if installed globally).
+
+To override this behavior, you can specify an explicit `juv` executable in the
+extension settings.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "juv",
   "displayName": "juv",
   "description": "Reproducible Jupyter notebooks, powered by uv.",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "engines": {
     "vscode": "^1.86.0"
   },
@@ -12,6 +12,16 @@
   "activationEvents": [],
   "main": "./src/extension.js",
   "contributes": {
+    "configuration": {
+      "type": "object",
+      "title": "juv Settings",
+      "properties": {
+        "juv.executable": {
+          "type": "string",
+          "description": "Path to the juv executable or a command to run juv CLI."
+        }
+      }
+    },
     "commands": [
       {
         "command": "juv.sync",


### PR DESCRIPTION
The extension now detects whether `uv` or `juv` is available, prioritizing `uvx juv` for execution. This makes it more likely to work out-of-the-box while and allowing better control over the `juv` version run in the extension.

Also introduces a `juv.executable` configuration option to let users explicitly specify the command or path if they prefer to override the default behavior.

```json
{
  "juv.executable": "/path/to/juv"
}
```
